### PR TITLE
BRZ Definition Updates

### DIFF
--- a/ECUFlash/subaru standard/BRZ/ZA1JB01C.xml
+++ b/ECUFlash/subaru standard/BRZ/ZA1JB01C.xml
@@ -211,13 +211,13 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table name="X" address="104dd0" elements="6" />
     <table name="Y" address="104de8" elements="10" />
   </table>
-  <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
-    <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
-            <table type="Y Axis" storageaddress="1044A0" />
-    </table>
-    <table name="Engine Load Limit C (Maximum) (RPM)" storageaddress="1044FC" >
-            <table type="Y Axis" storageaddress="1044D8" />
-    </table>
+  <table name="Engine Load Limit (Maximum)" address="4AC9C" />
+  <table name="Engine Load Limit B Maximum (RPM)" address="1044C4">
+    <table name="Y" address="1044A0" elements="9" />
+  </table>
+  <table name="Engine Load Limit C (Maximum) (RPM)" address="1044FC">
+    <table name="Y" address="1044D8" elements="9" />
+  </table>
   <table name="Engine Load Compensation (MP)" address="104ed4">
     <table name="X" address="104e60" elements="14" />
     <table name="Y" address="104e98" />

--- a/ECUFlash/subaru standard/BRZ/ZA1JB01C.xml
+++ b/ECUFlash/subaru standard/BRZ/ZA1JB01C.xml
@@ -211,7 +211,13 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table name="X" address="104dd0" elements="6" />
     <table name="Y" address="104de8" elements="10" />
   </table>
-  <table name="Engine Load Limit (Maximum)" address="4ac9c" />
+  <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
+    <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
+            <table type="Y Axis" storageaddress="1044A0" />
+    </table>
+    <table name="Engine Load Limit C (Maximum) (RPM)" storageaddress="1044FC" >
+            <table type="Y Axis" storageaddress="1044D8" />
+    </table>
   <table name="Engine Load Compensation (MP)" address="104ed4">
     <table name="X" address="104e60" elements="14" />
     <table name="Y" address="104e98" />

--- a/RomRaider/ecu/RR_ZA1JA00C.xml
+++ b/RomRaider/ecu/RR_ZA1JA00C.xml
@@ -215,7 +215,7 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table type="X Axis" storageaddress="11C8DC" />
     <table type="Y Axis" storageaddress="11C908" />
 </table>
-    <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
+    <table name="Engine Load Limit (Maximum)" storageaddress="4AC6C" />
     <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
             <table type="Y Axis" storageaddress="1044A0" />
     </table>

--- a/RomRaider/ecu/RR_ZA1JA00C.xml
+++ b/RomRaider/ecu/RR_ZA1JA00C.xml
@@ -215,7 +215,13 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table type="X Axis" storageaddress="11C8DC" />
     <table type="Y Axis" storageaddress="11C908" />
 </table>
-    <table name="Engine Load Limit (Maximum)" storageaddress="4AC6C" />
+    <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
+    <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
+            <table type="Y Axis" storageaddress="1044A0" />
+    </table>
+    <table name="Engine Load Limit C (Maximum) (RPM)" storageaddress="1044FC" >
+            <table type="Y Axis" storageaddress="1044D8" />
+    </table>
     <table name="Engine Load Compensation (MP)" storageaddress="104ED4" sizex="14">
       <table type="X Axis" storageaddress="104E60" />
       <table type="Y Axis" storageaddress="104E98" />
@@ -3403,19 +3409,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit B Maximum (RPM)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="2" userlevel="4">
+    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
       <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B (Maximum)" category="Mass Airflow / Engine Load" storagetype="float" endian="little" sizey="1" userlevel="3">
-      <scaling units="Engine Load (g/rev)" expression="x" to_byte="x" format="0.00" fineincrement=".01" coarseincrement=".1" />
-      <table type="Static Y Axis" name="Capped Limit" sizey="1">
-        <data>Maximum</data>
+    <table type="2D" name="Engine Load Limit C (Maximum) (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
+      <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
+      <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
+        <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
-      <description>This is the maximum allowable engine load under specific conditions. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it can also impact the max engine load.</description>
+      <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
     <table type="3D" name="Engine Load Compensation (MP)" category="Mass Airflow / Engine Load" storagetype="uint8" endian="big" sizex="11" sizey="15" userlevel="3">
       <scaling units="Engine Load Compensation (%)" expression="(x*.390625)-50" to_byte="(x+50)/.390625" format="0.0" fineincrement=".2" coarseincrement="1" />
@@ -7645,19 +7651,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>no description</description>
     </table>
-    <table type="2D" name="Port Injection MRP Compensation" category="Alpha - BRZ" storagetype="float" endian="big" sizey="16" userlevel="4">
+    <table type="2D" name="Port Injection MRP Compensation" category="Fueling - Injectors" storagetype="float" endian="big" sizey="16" userlevel="4">
       <scaling units="Ratio" expression="x" to_byte="x" format="0.000" fineincrement=".01" coarseincrement=".1" />
-      <table type="Y Axis" name="Manifold Pressure" storagetype="float" endian="little" logparam="E52">
-        <scaling units="psi relative sea level" expression="(x-760)*.01933677" to_byte="(x/.01933677)+760" format="#0.00" fineincrement=".01" coarseincrement=".5" />
+      <table type="Y Axis" name="Manifold Relative Pressure" storagetype="float" endian="little" logparam="E52">
+        <scaling units="psi relative sea level" expression="x*.01933677" to_byte="x/.01933677" format="#0.00" fineincrement=".01" coarseincrement=".5" />
       </table>
-      <description>no description</description>
+      <description>Port injection compensation ratio against manifold relative pressure</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Maximum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="12" userlevel="4">
-      <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />
+      <scaling units="Injection Volume (ml)" expression="x/100" to_byte="x*100" format="0.000" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="big">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="10" coarseincrement="100" />
       </table>
-      <description>no description</description>
+      <description>Maximum direct injection volume (ml). If the maximum direct injection volume is hit you need to either increase this value or increase the ratio for the Total Injection Ratio Port maps. If you do not the ecu will simply stop injecting more fuel as it has reached the maxiumum allowance.</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Minimum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="6" userlevel="4">
       <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />

--- a/RomRaider/ecu/RR_ZA1JA01C.xml
+++ b/RomRaider/ecu/RR_ZA1JA01C.xml
@@ -218,7 +218,13 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table type="X Axis" storageaddress="11C8DC" />
     <table type="Y Axis" storageaddress="11C908" />
 </table>
-    <table name="Engine Load Limit (Maximum)" storageaddress="4AC6C" />
+    <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
+    <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
+            <table type="Y Axis" storageaddress="1044A0" />
+    </table>
+    <table name="Engine Load Limit C (Maximum) (RPM)" storageaddress="1044FC" >
+            <table type="Y Axis" storageaddress="1044D8" />
+    </table>
     <table name="Engine Load Compensation (MP)" storageaddress="104ED4" sizex="14">
       <table type="X Axis" storageaddress="104E60" />
       <table type="Y Axis" storageaddress="104E98" />
@@ -3382,19 +3388,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit B Maximum (RPM)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="2" userlevel="4">
+    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
       <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B (Maximum)" category="Mass Airflow / Engine Load" storagetype="float" endian="little" sizey="1" userlevel="3">
-      <scaling units="Engine Load (g/rev)" expression="x" to_byte="x" format="0.00" fineincrement=".01" coarseincrement=".1" />
-      <table type="Static Y Axis" name="Capped Limit" sizey="1">
-        <data>Maximum</data>
+    <table type="2D" name="Engine Load Limit C (Maximum) (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
+      <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
+      <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
+        <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
-      <description>This is the maximum allowable engine load under specific conditions. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it can also impact the max engine load.</description>
+      <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
     <table type="3D" name="Engine Load Compensation (MP)" category="Mass Airflow / Engine Load" storagetype="uint8" endian="big" sizex="11" sizey="15" userlevel="3">
       <scaling units="Engine Load Compensation (%)" expression="(x*.390625)-50" to_byte="(x+50)/.390625" format="0.0" fineincrement=".2" coarseincrement="1" />
@@ -7624,19 +7630,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>no description</description>
     </table>
-    <table type="2D" name="Port Injection MRP Compensation" category="Alpha - BRZ" storagetype="float" endian="big" sizey="16" userlevel="4">
+    <table type="2D" name="Port Injection MRP Compensation" category="Fueling - Injectors" storagetype="float" endian="big" sizey="16" userlevel="4">
       <scaling units="Ratio" expression="x" to_byte="x" format="0.000" fineincrement=".01" coarseincrement=".1" />
-      <table type="Y Axis" name="Manifold Pressure" storagetype="float" endian="little" logparam="E52">
-        <scaling units="psi relative sea level" expression="(x-760)*.01933677" to_byte="(x/.01933677)+760" format="#0.00" fineincrement=".01" coarseincrement=".5" />
+      <table type="Y Axis" name="Manifold Relative Pressure" storagetype="float" endian="little" logparam="E52">
+        <scaling units="psi relative sea level" expression="x*.01933677" to_byte="x/.01933677" format="#0.00" fineincrement=".01" coarseincrement=".5" />
       </table>
-      <description>no description</description>
+      <description>Port injection compensation ratio against manifold relative pressure</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Maximum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="12" userlevel="4">
-      <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />
+      <scaling units="Injection Volume (ml)" expression="x/100" to_byte="x*100" format="0.000" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="big">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="10" coarseincrement="100" />
       </table>
-      <description>no description</description>
+      <description>Maximum direct injection volume (ml). If the maximum direct injection volume is hit you need to either increase this value or increase the ratio for the Total Injection Ratio Port maps. If you do not the ecu will simply stop injecting more fuel as it has reached the maxiumum allowance.</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Minimum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="6" userlevel="4">
       <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />

--- a/RomRaider/ecu/RR_ZA1JA01C.xml
+++ b/RomRaider/ecu/RR_ZA1JA01C.xml
@@ -218,7 +218,7 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table type="X Axis" storageaddress="11C8DC" />
     <table type="Y Axis" storageaddress="11C908" />
 </table>
-    <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
+    <table name="Engine Load Limit (Maximum)" storageaddress="4AC6C" />
     <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
             <table type="Y Axis" storageaddress="1044A0" />
     </table>

--- a/RomRaider/ecu/RR_ZA1JA01D.xml
+++ b/RomRaider/ecu/RR_ZA1JA01D.xml
@@ -215,7 +215,7 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table type="X Axis" storageaddress="11C828" />
     <table type="Y Axis" storageaddress="11C854" />
 </table>
-    <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
+    <table name="Engine Load Limit (Maximum)" storageaddress="4AC6C" />
     <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
             <table type="Y Axis" storageaddress="1044A0" />
     </table>

--- a/RomRaider/ecu/RR_ZA1JA01D.xml
+++ b/RomRaider/ecu/RR_ZA1JA01D.xml
@@ -215,7 +215,13 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table type="X Axis" storageaddress="11C828" />
     <table type="Y Axis" storageaddress="11C854" />
 </table>
-    <table name="Engine Load Limit (Maximum)" storageaddress="4AC6C" />
+    <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
+    <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
+            <table type="Y Axis" storageaddress="1044A0" />
+    </table>
+    <table name="Engine Load Limit C (Maximum) (RPM)" storageaddress="1044FC" >
+            <table type="Y Axis" storageaddress="1044D8" />
+    </table>
     <table name="Engine Load Compensation (MP)" storageaddress="104ED4" sizex="14">
       <table type="X Axis" storageaddress="104E60" />
       <table type="Y Axis" storageaddress="104E98" />
@@ -3362,19 +3368,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit B Maximum (RPM)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="2" userlevel="4">
+    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
       <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B (Maximum)" category="Mass Airflow / Engine Load" storagetype="float" endian="little" sizey="1" userlevel="3">
-      <scaling units="Engine Load (g/rev)" expression="x" to_byte="x" format="0.00" fineincrement=".01" coarseincrement=".1" />
-      <table type="Static Y Axis" name="Capped Limit" sizey="1">
-        <data>Maximum</data>
+    <table type="2D" name="Engine Load Limit C (Maximum) (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
+      <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
+      <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
+        <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
-      <description>This is the maximum allowable engine load under specific conditions. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it can also impact the max engine load.</description>
+      <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
     <table type="3D" name="Engine Load Compensation (MP)" category="Mass Airflow / Engine Load" storagetype="uint8" endian="big" sizex="11" sizey="15" userlevel="3">
       <scaling units="Engine Load Compensation (%)" expression="(x*.390625)-50" to_byte="(x+50)/.390625" format="0.0" fineincrement=".2" coarseincrement="1" />
@@ -7658,19 +7664,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>no description</description>
     </table>
-    <table type="2D" name="Port Injection MRP Compensation" category="Alpha - BRZ" storagetype="float" endian="big" sizey="16" userlevel="4">
+    <table type="2D" name="Port Injection MRP Compensation" category="Fueling - Injectors" storagetype="float" endian="big" sizey="16" userlevel="4">
       <scaling units="Ratio" expression="x" to_byte="x" format="0.000" fineincrement=".01" coarseincrement=".1" />
-      <table type="Y Axis" name="Manifold Pressure" storagetype="float" endian="little" logparam="E52">
-        <scaling units="psi relative sea level" expression="(x-760)*.01933677" to_byte="(x/.01933677)+760" format="#0.00" fineincrement=".01" coarseincrement=".5" />
+      <table type="Y Axis" name="Manifold Relative Pressure" storagetype="float" endian="little" logparam="E52">
+        <scaling units="psi relative sea level" expression="x*.01933677" to_byte="x/.01933677" format="#0.00" fineincrement=".01" coarseincrement=".5" />
       </table>
-      <description>no description</description>
+      <description>Port injection compensation ratio against manifold relative pressure</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Maximum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="12" userlevel="4">
-      <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />
+      <scaling units="Injection Volume (ml)" expression="x/100" to_byte="x*100" format="0.000" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="big">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="10" coarseincrement="100" />
       </table>
-      <description>no description</description>
+      <description>Maximum direct injection volume (ml). If the maximum direct injection volume is hit you need to either increase this value or increase the ratio for the Total Injection Ratio Port maps. If you do not the ecu will simply stop injecting more fuel as it has reached the maxiumum allowance.</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Minimum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="6" userlevel="4">
       <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />

--- a/RomRaider/ecu/RR_ZA1JB00C.xml
+++ b/RomRaider/ecu/RR_ZA1JB00C.xml
@@ -216,6 +216,12 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table type="Y Axis" storageaddress="11C944" />
 </table>
     <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
+    <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
+            <table type="Y Axis" storageaddress="1044A0" />
+    </table>
+    <table name="Engine Load Limit C (Maximum) (RPM)" storageaddress="1044FC" >
+            <table type="Y Axis" storageaddress="1044D8" />
+    </table>
     <table name="Engine Load Compensation (MP)" storageaddress="104ED4" sizex="14">
       <table type="X Axis" storageaddress="104E60" />
       <table type="Y Axis" storageaddress="104E98" />
@@ -3353,19 +3359,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit B Maximum (RPM)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="2" userlevel="4">
+    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
       <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B (Maximum)" category="Mass Airflow / Engine Load" storagetype="float" endian="little" sizey="1" userlevel="3">
-      <scaling units="Engine Load (g/rev)" expression="x" to_byte="x" format="0.00" fineincrement=".01" coarseincrement=".1" />
-      <table type="Static Y Axis" name="Capped Limit" sizey="1">
-        <data>Maximum</data>
+    <table type="2D" name="Engine Load Limit C (Maximum) (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
+      <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
+      <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
+        <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
-      <description>This is the maximum allowable engine load under specific conditions. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it can also impact the max engine load.</description>
+      <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
     <table type="3D" name="Engine Load Compensation (MP)" category="Mass Airflow / Engine Load" storagetype="uint8" endian="big" sizex="11" sizey="15" userlevel="3">
       <scaling units="Engine Load Compensation (%)" expression="(x*.390625)-50" to_byte="(x+50)/.390625" format="0.0" fineincrement=".2" coarseincrement="1" />
@@ -7596,19 +7602,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>no description</description>
     </table>
-    <table type="2D" name="Port Injection MRP Compensation" category="Alpha - BRZ" storagetype="float" endian="big" sizey="16" userlevel="4">
+    <table type="2D" name="Port Injection MRP Compensation" category="Fueling - Injectors" storagetype="float" endian="big" sizey="16" userlevel="4">
       <scaling units="Ratio" expression="x" to_byte="x" format="0.000" fineincrement=".01" coarseincrement=".1" />
-      <table type="Y Axis" name="Manifold Pressure" storagetype="float" endian="little" logparam="E52">
-        <scaling units="psi relative sea level" expression="(x-760)*.01933677" to_byte="(x/.01933677)+760" format="#0.00" fineincrement=".01" coarseincrement=".5" />
+      <table type="Y Axis" name="Manifold Relative Pressure" storagetype="float" endian="little" logparam="E52">
+        <scaling units="psi relative sea level" expression="x*.01933677" to_byte="x/.01933677" format="#0.00" fineincrement=".01" coarseincrement=".5" />
       </table>
-      <description>no description</description>
+      <description>Port injection compensation ratio against manifold relative pressure</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Maximum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="12" userlevel="4">
-      <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />
+      <scaling units="Injection Volume (ml)" expression="x/100" to_byte="x*100" format="0.000" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="big">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="10" coarseincrement="100" />
       </table>
-      <description>no description</description>
+      <description>Maximum direct injection volume (ml). If the maximum direct injection volume is hit you need to either increase this value or increase the ratio for the Total Injection Ratio Port maps. If you do not the ecu will simply stop injecting more fuel as it has reached the maxiumum allowance.</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Minimum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="6" userlevel="4">
       <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />

--- a/RomRaider/ecu/RR_ZA1JB01C.xml
+++ b/RomRaider/ecu/RR_ZA1JB01C.xml
@@ -7602,19 +7602,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>no description</description>
     </table>
-    <table type="2D" name="Port Injection MRP Compensation" category="Alpha - BRZ" storagetype="float" endian="big" sizey="16" userlevel="4">
+    <table type="2D" name="Port Injection MRP Compensation" category="Fueling - Injectors" storagetype="float" endian="big" sizey="16" userlevel="4">
       <scaling units="Ratio" expression="x" to_byte="x" format="0.000" fineincrement=".01" coarseincrement=".1" />
-      <table type="Y Axis" name="Manifold Pressure" storagetype="float" endian="little" logparam="E52">
-        <scaling units="psi relative sea level" expression="(x-760)*.01933677" to_byte="(x/.01933677)+760" format="#0.00" fineincrement=".01" coarseincrement=".5" />
+      <table type="Y Axis" name="Manifold Relative Pressure" storagetype="float" endian="little" logparam="E52">
+        <scaling units="psi relative sea level" expression="x*.01933677" to_byte="x/.01933677" format="#0.00" fineincrement=".01" coarseincrement=".5" />
       </table>
-      <description>no description</description>
+      <description>Port injection compensation ratio against manifold relative pressure</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Maximum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="12" userlevel="4">
-      <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />
+      <scaling units="Injection Volume (ml)" expression="x/100" to_byte="x*100" format="0.000" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="big">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="10" coarseincrement="100" />
       </table>
-      <description>no description</description>
+      <description>Maximum direct injection volume (ml). If the maximum direct injection volume is hit you need to either increase this value or increase the ratio for the Total Injection Ratio Port maps. If you do not the ecu will simply stop injecting more fuel as it has reached the maxiumum allowance.</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Minimum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="6" userlevel="4">
       <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />

--- a/RomRaider/ecu/RR_ZA1JB01D.xml
+++ b/RomRaider/ecu/RR_ZA1JB01D.xml
@@ -216,6 +216,12 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
     <table type="Y Axis" storageaddress="11C890" />
 </table>
     <table name="Engine Load Limit (Maximum)" storageaddress="4AC9C" />
+    <table name="Engine Load Limit B Maximum (RPM)" storageaddress="1044C4" >
+            <table type="Y Axis" storageaddress="1044A0" />
+    </table>
+    <table name="Engine Load Limit C (Maximum) (RPM)" storageaddress="1044FC" >
+            <table type="Y Axis" storageaddress="1044D8" />
+    </table>
     <table name="Engine Load Compensation (MP)" storageaddress="104ED4" sizex="14">
       <table type="X Axis" storageaddress="104E60" />
       <table type="Y Axis" storageaddress="104E98" />
@@ -3353,19 +3359,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit B Maximum (RPM)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="2" userlevel="4">
+    <table type="2D" name="Engine Load Limit B Maximum (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
       <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
       <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
-    <table type="2D" name="Engine Load Limit B (Maximum)" category="Mass Airflow / Engine Load" storagetype="float" endian="little" sizey="1" userlevel="3">
-      <scaling units="Engine Load (g/rev)" expression="x" to_byte="x" format="0.00" fineincrement=".01" coarseincrement=".1" />
-      <table type="Static Y Axis" name="Capped Limit" sizey="1">
-        <data>Maximum</data>
+    <table type="2D" name="Engine Load Limit C (Maximum) (RPM)" category="Mass Airflow / Engine Load" storagetype="uint16" endian="big" sizey="9" userlevel="4">
+      <scaling units="Engine Load (g/rev)" expression="x*.00006103516" to_byte="x/.00006103516" format="0.00" fineincrement=".01" coarseincrement=".1" />
+      <table type="Y Axis" name="Engine Speed" storagetype="float" endian="little" logparam="P8">
+        <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="50" coarseincrement="100" />
       </table>
-      <description>This is the maximum allowable engine load under specific conditions. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it can also impact the max engine load.</description>
+      <description>This is the maximum allowable engine load. Engine load will be capped at this limit regardless of actual engine load. "Engine Load Limit A (Maximum)" must also be changed as it also impacts the max engine load.</description>
     </table>
     <table type="3D" name="Engine Load Compensation (MP)" category="Mass Airflow / Engine Load" storagetype="uint8" endian="big" sizex="11" sizey="15" userlevel="3">
       <scaling units="Engine Load Compensation (%)" expression="(x*.390625)-50" to_byte="(x+50)/.390625" format="0.0" fineincrement=".2" coarseincrement="1" />
@@ -7591,19 +7597,19 @@ for any damage or injury incurred as a result of these definitions. USE AT YOUR 
       </table>
       <description>no description</description>
     </table>
-    <table type="2D" name="Port Injection MRP Compensation" category="Alpha - BRZ" storagetype="float" endian="big" sizey="16" userlevel="4">
+    <table type="2D" name="Port Injection MRP Compensation" category="Fueling - Injectors" storagetype="float" endian="big" sizey="16" userlevel="4">
       <scaling units="Ratio" expression="x" to_byte="x" format="0.000" fineincrement=".01" coarseincrement=".1" />
-      <table type="Y Axis" name="Manifold Pressure" storagetype="float" endian="little" logparam="E52">
-        <scaling units="psi relative sea level" expression="(x-760)*.01933677" to_byte="(x/.01933677)+760" format="#0.00" fineincrement=".01" coarseincrement=".5" />
+      <table type="Y Axis" name="Manifold Relative Pressure" storagetype="float" endian="little" logparam="E52">
+        <scaling units="psi relative sea level" expression="x*.01933677" to_byte="x/.01933677" format="#0.00" fineincrement=".01" coarseincrement=".5" />
       </table>
-      <description>no description</description>
+      <description>Port injection compensation ratio against manifold relative pressure</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Maximum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="12" userlevel="4">
-      <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />
+      <scaling units="Injection Volume (ml)" expression="x/100" to_byte="x*100" format="0.000" fineincrement=".01" coarseincrement=".1" />
       <table type="Y Axis" name="Engine Speed" storagetype="float" endian="big">
         <scaling units="RPM" expression="x" to_byte="x" format="#" fineincrement="10" coarseincrement="100" />
       </table>
-      <description>no description</description>
+      <description>Maximum direct injection volume (ml). If the maximum direct injection volume is hit you need to either increase this value or increase the ratio for the Total Injection Ratio Port maps. If you do not the ecu will simply stop injecting more fuel as it has reached the maxiumum allowance.</description>
     </table>
     <table type="2D" name="Direct Injection Quantity Minimum" category="Alpha - BRZ" storagetype="float" endian="big" sizey="6" userlevel="4">
       <scaling units="Unknown" expression="x" to_byte="x" format="#" fineincrement=".01" coarseincrement=".1" />


### PR DESCRIPTION
This updates the following RomRaider roms: A00C, A01C, A01D, B00C, B01C, B01D
Added ECU Load Limit B & C.

Updated the axis definition for Port Injection MRP Compensation table. The axis was previously displaying -1bar off of the actual value.
Moved Port Injection MRP Compensation from BRZ - Alpha to Fuel - Injectors
Updated axis definition & description for Direct Injection Maximum. Values now represent ml injection volume.

Updated the ECUFlash definition for B01C to include the load limit tables. However this is not adding any updates to the base files so the load limit C will need to be added manually and added to the base file at a later time.
