### PR TITLE
Updated definitions for alpha features from A2WC521N to A2WC521C

### DIFF
--- a/ECUFlash/subaru standard/Legacy GT/A2WC521C.xml
+++ b/ECUFlash/subaru standard/Legacy GT/A2WC521C.xml
@@ -1,523 +1,939 @@
 <rom>
-  <romid>
-    <xmlid>A2WC521C</xmlid>
-    <internalidaddress>2000</internalidaddress>
-    <internalidstring>A2WC521C</internalidstring>
-    <ecuid>2F12505506</ecuid>
-    <year>05</year>
-    <market>USDM</market>
-    <make>Subaru</make>
-    <model>Legacy</model>
-    <submodel>GT</submodel>
-    <transmission>AT</transmission>
-    <memmodel>SH7058</memmodel>
-    <flashmethod>sti05</flashmethod>
-    <checksummodule>subarudbw</checksummodule>
-  </romid>
-  <include>32BITBASE</include>
-  <table name="Target Boost A" address="c0fb4">
-    <table name="X" address="c0f64" />
-    <table name="Y" address="c0f84" />
-  </table>
-  <table name="Target Boost B" address="c10c4">
-    <table name="X" address="c1074" />
-    <table name="Y" address="c1094" />
-  </table>
-  <table name="Target Boost Compensation (ECT)" address="c0764">
-    <table name="Y" address="c05c4" />
-  </table>
-  <table name="Target Boost Compensation (1st Gear)" address="c05c0" />
-  <table name="Target Boost Compensation (1st Gear) Speed Disable" address="c05b8" />
-  <table name="Target Boost Compensation (Atm. Pressure) Multiplier" address="c0864">
-    <table name="Y" address="c0854" />
-  </table>
-  <table name="Target Boost Compensation (Atm. Pressure) Multiplier Offset" address="c0794">
-    <table name="Y" address="c0784" />
-  </table>
-  <table name="Boost Limit (Fuel Cut)" address="c803c">
-    <table name="Y" address="c8024" />
-  </table>
-  <table name="Boost Control Disable (IAM)" address="c0598" />
-  <table name="Boost Control Disable (Fine Correction)" address="c0594" />
-  <table name="Boost Control Disable Delay (Fine Correction)" address="c0535" />
-  <table name="Initial Wastegate Duty A" address="c09c8">
-    <table name="X" address="c097c" />
-    <table name="Y" address="c099c" elements="11" />
-  </table>
-  <table name="Initial Wastegate Duty B" address="c0ac4">
-    <table name="X" address="c0a78" />
-    <table name="Y" address="c0a98" elements="11" />
-  </table>
-  <table name="Max Wastegate Duty" address="c0db8">
-    <table name="X" address="c0d6c" />
-    <table name="Y" address="c0d8c" elements="11" />
-  </table>
-  <table name="Max Wastegate Duty Alternate A (RPM)" address="c08c0">
-    <table name="Y" address="c08ac" />
-  </table>
-  <table name="Max Wastegate Duty Alternate B (RPM)" address="c08e8">
-    <table name="Y" address="c08d4" />
-  </table>
-  <table name="Wastegate Duty Ramping Fix_" address="c0588" />
-  <table name="Max Wastegate Duty Alternate Fix" address="c0534" />
-  <table name="Max Wastegate Duty Limit Post-Compensation" address="15618" />
-  <table name="Initial/Max Wastegate Duty Compensation (IAT)" address="c0644">
-    <table name="Y" address="c0604" />
-  </table>
-  <table name="Initial/Max Wastegate Duty Alternate Compensation (IAT)" address="c06e4">
-    <table name="Y" address="c06a4" />
-  </table>
-  <table name="Initial/Max Wastegate Duty Compensation (ECT)" address="c0744">
-    <table name="Y" address="c05c4" />
-  </table>
-  <table name="Initial/Max Wastegate Duty Compensation (Atm. Pressure)" address="c0924">
-    <table name="X" address="c08fc" />
-    <table name="Y" address="c0914" />
-  </table>
-  <table name="Turbo Dynamics Proportional" address="c07d0">
-    <table name="Y" address="c07ac" />
-  </table>
-  <table name="Turbo Dynamics Integral Positive" address="c0840">
-    <table name="Y" address="c081c" />
-  </table>
-  <table name="Turbo Dynamics Integral Negative" address="c0808">
-    <table name="Y" address="c07e4" />
-  </table>
-  <table name="TD Activation Thresholds (RPM)" address="c056c" />
-  <table name="TD Activation Thresholds (Target Boost)" address="c0540" />
-  <table name="TD Integral Cumulative Range (WGDC Correction)" address="c057c" />
-  <table name="TD Integral Negative Activation (Boost Error)" address="c0550" />
-  <table name="TD Integral Positive Activation (Boost Error)" address="c0558" />
-  <table name="TD Integral Positive Activation (Wastegate Duty)" address="c0560" />
-  <table name="Manifold Pressure Sensor Scaling" address="c00c0" />
-  <table name="Manifold Pressure Sensor Limits (CEL)" address="ccd9a" />
-  <table name="Manifold Pressure Sensor CEL Delays" address="c310f" />
-  <table name="Primary Open Loop Fueling" address="c87cc">
-    <table name="X" address="c8744" elements="16" />
-    <table name="Y" address="c8784" />
-  </table>
-  <table name="Primary Open Loop Fueling (Failsafe)" address="c8988">
-    <table name="X" address="c8900" elements="16" />
-    <table name="Y" address="c8940" />
-  </table>
-  <table name="Primary Open Loop Fuel Map Switch (IAM)" address="c7020" />
-  <table name="Minimum Active Primary Open Loop Enrichment" address="c6f84" />
-  <table name="Minimum Primary Open Loop Enrichment (Throttle)" address="c76bc">
-    <table name="Y" address="c76a4" />
-  </table>
-  <table name="Primary Open Loop Fueling Compensation (ECT)" address="c7e88">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Primary Open Loop Fueling Compensation (Timing Compensation)" address="c76dc">
-    <table name="Y" address="c76c4" />
-  </table>
-  <table name="Front Oxygen Sensor Scaling" address="cd40c">
-    <table name="Y" address="cd3d8" />
-  </table>
-  <table name="Front Oxygen Sensor Rich Limit" address="22eb8" />
-  <table name="Front Oxygen Sensor Compensation (Atm. Pressure)" address="c27f4">
-    <table name="Y" address="c27e4" />
-  </table>
-  <table name="CL Fueling Target Compensation (Load)" address="c9208">
-    <table name="X" address="c91ac" elements="11" />
-    <table name="Y" address="c91d8" elements="12" />
-  </table>
-  <table name="CL Fueling Target Compensation A (ECT)" address="c9050">
-    <table name="X" address="c7344" />
-    <table name="Y" address="c9044" />
-  </table>
-  <table name="CL Fueling Target Compensation B (ECT)" address="c9104">
-    <table name="X" address="c7344" />
-    <table name="Y" address="c90f8" />
-  </table>
-  <table name="CL to OL Delay" address="c6bcc" />
-  <table name="CL to OL Transition with Delay A (Throttle)" address="c75f4">
-    <table name="Y" address="c75b4" />
-  </table>
-  <table name="CL to OL Transition with Delay B (Throttle)" address="c7644">
-    <table name="Y" address="c7604" />
-  </table>
-  <table name="CL to OL Transition with Delay C (Throttle)" address="c7694">
-    <table name="Y" address="c7654" />
-  </table>
-  <table name="CL to OL Transition with Delay Throttle Hysteresis" address="c6f88" />
-  <table name="CL to OL Transition with Delay A (Base Pulse Width)" address="c7da8">
-    <table name="Y" address="c7d68" />
-  </table>
-  <table name="CL to OL Transition with Delay B (Base Pulse Width)" address="c7e08">
-    <table name="Y" address="c7dc8" />
-  </table>
-  <table name="CL to OL Transition with Delay C (Base Pulse Width)" address="c7e68">
-    <table name="Y" address="c7e28" />
-  </table>
-  <table name="CL to OL Transition with Delay BPW Hysteresis" address="c6f8c" />
-  <table name="CL Delay Maximum (EGT)" address="c7008" />
-  <table name="CL Delay Maximum (Vehicle Speed)" address="c7000" />
-  <table name="CL Delay Minimum (ECT)" address="c6f90" />
-  <table name="CL Delay Maximum Engine Speed (Per Gear)" address="c6f94" />
-  <table name="CL Delay Maximum Engine Speed (Neutral)" address="c6fe4" />
-  <table name="CL Delay Throttle Atm. Pressure Thresholds" address="c7010" />
-  <table name="CL Delay Maximum (Throttle) (Low Atm. Pressure)" address="c6ff4" />
-  <table name="CL Delay Maximum (Throttle) (High Atm. Pressure)" address="c6fec" />
-  <table name="Injector Latency" address="cce8c">
-    <table name="Y" address="cce78" />
-  </table>
-  <table name="Injector Flow Scaling" address="c6d1c" />
-  <table name="Per Injector Primary Fuel Offset Compensation A" address="c8b00">
-    <table name="X" address="c8aa8" />
-    <table name="Y" address="c8ac8" />
-  </table>
-  <table name="Per Injector Primary Fuel Offset Compensation B" address="c8bc8">
-    <table name="X" address="c8b70" />
-    <table name="Y" address="c8b90" />
-  </table>
-  <table name="Per Injector Primary Fuel Offset Compensation C" address="c8c90">
-    <table name="X" address="c8c38" />
-    <table name="Y" address="c8c58" />
-  </table>
-  <table name="Per Injector Primary Fuel Offset Compensation D" address="c8d58">
-    <table name="X" address="c8d00" />
-    <table name="Y" address="c8d20" />
-  </table>
-  <table name="Cranking Fuel Injector Pulse Width A (ECT)" address="c78b2">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Cranking Fuel Injector Pulse Width B (ECT)" address="c78d2">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Cranking Fuel Injector Pulse Width C (ECT)" address="c78f2">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Cranking Fuel Injector Pulse Width D (ECT)" address="c7912">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Cranking Fuel IPW Compensation (RPM)" address="c85ec">
-    <table name="X" address="c85bc" />
-    <table name="Y" address="c85d0" />
-  </table>
-  <table name="Cranking Fuel IPW Compensation (Accelerator)" address="c7440">
-    <table name="Y" address="c7428" />
-  </table>
-  <table name="Throttle Tip-in Enrichment" address="c7f90">
-    <table name="Y" address="c7f48" />
-  </table>
-  <table name="Minimum Tip-in Enrichment Activation" address="c7110" />
-  <table name="Minimum Tip-in Enrichment Activation (Throttle)" address="c710c" />
-  <table name="Tip-in Enrichment Compensation (Boost Error)" address="c7750">
-    <table name="Y" address="c772c" />
-  </table>
-  <table name="Tip-in Enrichment Compensation (ECT)" address="c7fb4">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Tip-in Enrichment Disable Applied Counter Threshold" address="c6b95" />
-  <table name="Tip-in Enrichment Applied Counter Reset" address="c6b96" />
-  <table name="Tip-in Enrichment Disable Throttle Cumulative Threshold" address="c7114" />
-  <table name="Tip-in Throttle Cumulative Reset" address="c6b97" />
-  <table name="Min Primary Base Enrichment 1" address="c7496">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrichment 1 (Non-Primary OL)" address="c8718">
-    <table name="X" address="c86ec" elements="8" />
-    <table name="Y" address="c870c" />
-  </table>
-  <table name="Min Primary Base Enrich 2 Initial Start 1A" address="c79b2">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 2 Initial Start 1B" address="c79f2">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 2 Initial Start 2A" address="c79d2">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 2 Initial Start 2B" address="c7a12">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 2 Decay Step 1" address="c7a32">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 2 Decay Step 2" address="c7a52">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 3 Initial Start 1A" address="c7932">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 3 Initial Start 1B" address="c7952">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 3 Initial Start 2A" address="c7972">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 3 Initial Start 2B" address="c7992">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 3 Decay Delay A" address="c7456">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 3 Decay Delay B" address="c7466">
-    <table name="Y" address="c7344" />
-  </table>
-  <table name="Min Primary Base Enrich 3 Decay Multiplier" address="c6d20" />
-  <table name="A/F Learning #1 Limits" address="c6f4c" />
-  <table name="A/F Learning #1 Airflow Ranges" address="c6f58" />
-  <table name="MAF Limit (Maximum)" address="c23a0" />
-  <table name="MAF Sensor Scaling" address="cd210">
-    <table name="Y" address="cd138" />
-  </table>
-  <table name="MAF Compensation (IAT)" address="c2bb8">
-    <table name="X" address="c2b84" />
-    <table name="Y" address="c2b98" />
-  </table>
-  <table name="Engine Load Limit (Maximum)" address="20f90" />
-  <table name="Engine Load Compensation (MP)" address="c2b2c">
-    <table name="X" address="c2ae0" />
-    <table name="Y" address="c2b0c" elements="8" />
-  </table>
-  <table name="Base Timing" address="ca018">
-    <table name="X" address="c9f90" elements="16" />
-    <table name="Y" address="c9fd0" />
-  </table>
-  <table name="Base Timing Idle" address="c9871">
-    <table name="Y" address="c9714" />
-  </table>
-  <table name="Base Timing Idle Minimum" address="c9868">
-    <table name="Y" address="c9844" />
-  </table>
-  <table name="Base Timing Idle Minimum Vehicle Speed Enable" address="c945c" />
-  <table name="Knock Correction Advance Max" address="ca57c">
-    <table name="X" address="ca4f4" />
-    <table name="Y" address="ca534" />
-  </table>
-  <table name="Timing Compensation A (IAT)" address="c98e4">
-    <table name="Y" address="c98a4" />
-  </table>
-  <table name="Timing Compensation A (IAT) Activation" address="ca178">
-    <table name="X" address="ca138" />
-    <table name="Y" address="ca158" />
-  </table>
-  <table name="Timing Compensation B (IAT)" address="c9c5c">
-    <table name="Y" address="c9c1c" />
-  </table>
-  <table name="Timing Compensation B (IAT) IAM Activation" address="c9710" />
-  <table name="Timing Compensation B (IAT) Max Additive" address="c96f4" />
-  <table name="Timing Compensation (ECT)" address="c9891">
-    <table name="Y" address="c9714" />
-  </table>
-  <table name="Timing Compensation (MRP)" address="ca6d0">
-    <table name="X" address="ca6b0" />
-    <table name="Y" address="ca6c4" />
-  </table>
-  <table name="Timing Compensation Per Cylinder A" address="ca308">
-    <table name="X" address="ca2c0" />
-    <table name="Y" address="ca2f8" />
-  </table>
-  <table name="Timing Compensation Per Cylinder B" address="ca388">
-    <table name="X" address="ca340" />
-    <table name="Y" address="ca378" />
-  </table>
-  <table name="Timing Compensation Per Cylinder C" address="ca408">
-    <table name="X" address="ca3c0" />
-    <table name="Y" address="ca3f8" />
-  </table>
-  <table name="Timing Compensation Per Cylinder D" address="ca488">
-    <table name="X" address="ca440" />
-    <table name="Y" address="ca478" />
-  </table>
-  <table name="Timing Comp Minimum Load (Per Cylinder)" address="c9570" />
-  <table name="Timing Comp Maximum RPM (Per Cylinder)" address="c956c" />
-  <table name="Timing Comp Minimum Coolant Temp (Per Cylinder)" address="c9574" />
-  <table name="Feedback Correction Range (RPM)" address="c95a8" />
-  <table name="Feedback Correction Minimum Load" address="c95b8" />
-  <table name="Feedback Correction Retard Value" address="c9588" />
-  <table name="Feedback Correction Retard Limit" address="c9584" />
-  <table name="Feedback Correction Negative Advance Value" address="c9590" />
-  <table name="Feedback Correction Negative Advance Delay" address="c9388" />
-  <table name="Extended Feedback Correction High RPM Compensation" address="c95c0" />
-  <table name="Fine Correction Range (RPM)" address="c96a0" />
-  <table name="Fine Correction Range (Load)" address="c96b0" />
-  <table name="Fine Correction Rows (RPM)" address="c96d0" />
-  <table name="Fine Correction Columns (Load)" address="c96c0" />
-  <table name="Fine Correction Retard Value" address="c96e8" />
-  <table name="Fine Correction Retard Limit" address="c9698" />
-  <table name="Fine Correction Advance Value" address="c969c" />
-  <table name="Fine Correction Advance Limit" address="c9694" />
-  <table name="Fine Correction Advance Delay" address="c9396" />
-  <table name="Rough Correction Range (RPM)" address="c9638" />
-  <table name="Rough Correction Range (Load)" address="c9648" />
-  <table name="Rough Correction Minimum KC Advance Map Value" address="c9658" />
-  <table name="Rough Correction Learning Delay (Increasing)" address="c9c10">
-    <table name="Y" address="c9be8" />
-  </table>
-  <table name="Advance Multiplier (Initial)" address="c9634" />
-  <table name="Advance Multiplier Step Value" address="c965c" />
-  <table name="Intake Cam Advance Angle (AVCS)" address="ce74c">
-    <table name="X" address="ce6fc" elements="10" />
-    <table name="Y" address="ce724" elements="10" />
-  </table>
-  <table name="Requested Torque (Accelerator Pedal)" address="cc014">
-    <table name="X" address="cbf9c" />
-    <table name="Y" address="cbfd8" elements="15" />
-  </table>
-  <table name="Target Throttle Plate Position (Requested Torque)" address="cbd7c">
-    <table name="X" address="cbcf8" />
-    <table name="Y" address="cbd3c" />
-  </table>
-  <table name="Rev Limit (Fuel Cut)" address="c7164" />
-  <table name="Rev Limit Fuel Resume (Boost)" address="c716c" />
-  <table name="Speed Limiting Enable (Fuel Cut)" address="c71b0" />
-  <table name="Speed Limiting Disable (Fuel Cut)" address="c71b8" />
-  <table name="Speed Limiting (Throttle)" address="c2658" />
-  <table name="EGT Sensor Scaling" address="cd360">
-    <table name="Y" address="cd2e8" />
-  </table>
-  <table name="Fuel Temp Sensor Scaling" address="cd0c0">
-    <table name="Y" address="cd048" />
-  </table>
-  <table name="Intake Temp Sensor Scaling" address="85964">
-    <table name="Y" address="858ec" />
-  </table>
-  <table name="Coolant Temp Sensor Scaling" address="8587c">
-    <table name="Y" address="8580c" />
-  </table>
-  <table name="Atmospheric Pressure Sensor Scaling" address="c0070" />
-  <table name="Radiator Fan Modes (ECT)" address="cdb68" />
-  <table name="Radiator Fan Modes (Veh. Speed)" address="cdb78" />
-  <table name="Idle Speed Target A" address="cb2dc">
-    <table name="Y" address="cac94" />
-  </table>
-  <table name="Idle Speed Target B" address="cb31c">
-    <table name="Y" address="cac94" />
-  </table>
-  <table name="Idle Speed Target C" address="cb35c">
-    <table name="Y" address="cac94" />
-  </table>
-  <table name="Force Pass Readiness Monitors" address="78252" />
-  <table name="(P0000) PASS CODE (NO DTC DETECTED)" address="74fa3" />
-  <table name="(P0000) PASS CODE (NO DTC DETECTED)_" address="74fa4" />
-  <table name="(P0011) CAMSHAFT POS. - TIMING OVER-ADVANCED 1" address="74f89" />
-  <table name="(P0021) CAMSHAFT POS. - TIMING OVER-ADVANCED 2" address="74f8a" />
-  <table name="(P0030) FRONT O2 SENSOR RANGE/PERF" address="74fc8" />
-  <table name="(P0031) FRONT O2 SENSOR LOW INPUT" address="74faf" />
-  <table name="(P0032) FRONT O2 SENSOR HIGH INPUT" address="74fad" />
-  <table name="(P0037) REAR O2 SENSOR LOW INPUT" address="74fae" />
-  <table name="(P0038) REAR O2 SENSOR HIGH INPUT" address="74fac" />
-  <table name="(P0068) MAP SENSOR RANGE/PERF" address="74fc4" />
-  <table name="(P0101) MAF SENSOR RANGE/PERF" address="74fc6" />
-  <table name="(P0102) MAF SENSOR LOW INPUT" address="74f65" />
-  <table name="(P0103) MAF SENSOR HIGH INPUT" address="74f66" />
-  <table name="(P0107) MAP SENSOR LOW INPUT" address="74fb0" />
-  <table name="(P0108) MAP SENSOR HIGH INPUT" address="74fb1" />
-  <table name="(P0111) IAT SENSOR RANGE/PERF" address="74fab" />
-  <table name="(P0112) IAT SENSOR LOW INPUT" address="74fa9" />
-  <table name="(P0113) IAT SENSOR HIGH INPUT" address="74faa" />
-  <table name="(P0117) COOLANT TEMP SENSOR LOW INPUT" address="74f6d" />
-  <table name="(P0118) COOLANT TEMP SENSOR HIGH INPUT" address="74f6e" />
-  <table name="(P0122) TPS A LOW INPUT" address="74f6a" />
-  <table name="(P0123) TPS A HIGH INPUT" address="74f6b" />
-  <table name="(P0125) INSUFFICIENT COOLANT TEMP (FUELING)" address="74f70" />
-  <table name="(P0126) INSUFFICIENT COOLANT TEMP (OPERATION)" address="74ff1" />
-  <table name="(P0128) THERMOSTAT MALFUNCTION" address="74fb2" />
-  <table name="(P0131) FRONT O2 SENSOR LOW INPUT" address="74fa6" />
-  <table name="(P0132) FRONT O2 SENSOR HIGH INPUT" address="74fa7" />
-  <table name="(P0133) FRONT O2 SENSOR SLOW RESPONSE" address="74f94" />
-  <table name="(P0134) FRONT O2 SENSOR NO ACTIVITY" address="74fc7" />
-  <table name="(P0137) REAR O2 SENSOR LOW VOLTAGE" address="74fa5" />
-  <table name="(P0138) REAR O2 SENSOR HIGH VOLTAGE" address="74fa8" />
-  <table name="(P0139) REAR O2 SENSOR SLOW RESPONSE" address="74f95" />
-  <table name="(P0171) SYSTEM TOO LEAN" address="74f9b" />
-  <table name="(P0172) SYSTEM TOO RICH" address="74f9c" />
-  <table name="(P0181) FUEL TEMP SENSOR A RANGE/PERF" address="74f7d" />
-  <table name="(P0182) FUEL TEMP SENSOR A LOW INPUT" address="74f7b" />
-  <table name="(P0183) FUEL TEMP SENSOR A HIGH INPUT" address="74f7c" />
-  <table name="(P0222) TPS B LOW INPUT" address="74fcb" />
-  <table name="(P0223) TPS B HIGH INPUT" address="74fcc" />
-  <table name="(P0230) FUEL PUMP PRIMARY CIRCUIT" address="74fc3" />
-  <table name="(P0244) WASTEGATE SOLENOID A RANGE/PERF" address="74fb9" />
-  <table name="(P0245) WASTEGATE SOLENOID A LOW" address="74fb7" />
-  <table name="(P0246) WASTEGATE SOLENOID A HIGH" address="74fb8" />
-  <table name="(P0301) MISFIRE CYLINDER 1" address="74f9d" />
-  <table name="(P0302) MISFIRE CYLINDER 2" address="74f9e" />
-  <table name="(P0303) MISFIRE CYLINDER 3" address="74f9f" />
-  <table name="(P0304) MISFIRE CYLINDER 4" address="74fa0" />
-  <table name="(P0327) KNOCK SENSOR 1 LOW INPUT" address="74f68" />
-  <table name="(P0328) KNOCK SENSOR 1 HIGH INPUT" address="74f69" />
-  <table name="(P0335) CRANKSHAFT POS. SENSOR A MALFUNCTION" address="74f60" />
-  <table name="(P0336) CRANKSHAFT POS. SENSOR A RANGE/PERF" address="74f61" />
-  <table name="(P0340) CAMSHAFT POS. SENSOR A MALFUNCTION_" address="74fdf" />
-  <table name="(P0345) CAMSHAFT POS. SENSOR A BANK 2" address="74fde" />
-  <table name="(P0420) CAT EFFICIENCY BELOW THRESHOLD" address="74f98" />
-  <table name="(P0442) EVAP LEAK DETECTED (SMALL)" address="74f99" />
-  <table name="(P0447) EVAP VENT CONTROL CIRCUIT OPEN" address="74f92" />
-  <table name="(P0448) EVAP VENT CONTROL CIRCUIT SHORTED" address="74f93" />
-  <table name="(P0451) EVAP PRESSURE SENSOR RANGE/PERF" address="74f79" />
-  <table name="(P0452) EVAP PRESSURE SENSOR LOW INPUT" address="74f77" />
-  <table name="(P0453) EVAP PRESSURE SENSOR HIGH INPUT" address="74f78" />
-  <table name="(P0456) EVAP LEAK DETECTED (VERY SMALL)" address="74f9a" />
-  <table name="(P0457) EVAP LEAK DETECTED (FUEL CAP)" address="74fa2" />
-  <table name="(P0458) EVAP PURGE VALVE CIRCUIT LOW" address="74f8d" />
-  <table name="(P0459) EVAP PURGE VALVE CIRCUIT HIGH" address="74f8e" />
-  <table name="(P0461) FUEL LEVEL SENSOR RANGE/PERF" address="74f73" />
-  <table name="(P0462) FUEL LEVEL SENSOR LOW INPUT" address="74f71" />
-  <table name="(P0463) FUEL LEVEL SENSOR HIGH INPUT" address="74f72" />
-  <table name="(P0464) FUEL LEVEL SENSOR INTERMITTENT" address="74f6f" />
-  <table name="(P0483) RADIATOR FAN RATIONALITY CHECK" address="74f85" />
-  <table name="(P0500) VEHICLE SPEED SENSOR A" address="74f67" />
-  <table name="(P0506) IDLE CONTROL RPM LOWER THAN EXPECTED" address="74f81" />
-  <table name="(P0507) IDLE CONTROL RPM HIGH THAN EXPECTED" address="74f82" />
-  <table name="(P0512) STARTER REQUEST CIRCUIT" address="74f76" />
-  <table name="(P0519) IDLE CONTROL MALFUNCTION (FAIL-SAFE)" address="74fc5" />
-  <table name="(P0545) EGT SENSOR CIRCUIT LOW" address="74fbe" />
-  <table name="(P0546) EGT SENSOR CIRCUIT HIGH" address="74fbf" />
-  <table name="(P0600) SERIAL COMMUNICATION LINK" address="74fdb" />
-  <table name="(P0604) CONTROL MODULE RAM ERROR" address="74f64" />
-  <table name="(P0605) CONTROL MODULE ROM ERROR" address="74fe0" />
-  <table name="(P0607) CONTROL MODULE PERFORMANCE" address="74fd3" />
-  <table name="(P0638) THROTTLE ACTUATOR RANGE/PERF" address="74fd2" />
-  <table name="(P0691) RADIATOR FAN CIRCUIT LOW" address="74f83" />
-  <table name="(P0692) RADIATOR FAN CIRCUIT HIGH" address="74f84" />
-  <table name="(P0700) TRANSMISSION CONTROL SYSTEM" address="74fe9" />
-  <table name="(P0851) NEUTRAL SWITCH INPUT LOW" address="74f7a" />
-  <table name="(P0852) NEUTRAL SWITCH INPUT HIGH" address="74f7e" />
-  <table name="(P1152) FRONT O2 SENSOR RANGE/PERF LOW B1 S1" address="74f96" />
-  <table name="(P1153) FRONT O2 SENSOR RANGE/PERF HIGH B1 S1" address="74f97" />
-  <table name="(P1160) ABNORMAL RETURN SPRING" address="74fcd" />
-  <table name="(P1301) MISFIRE (HIGH TEMP EXHAUST GAS)" address="74fa1" />
-  <table name="(P1312) EGT SENSOR MALFUNCTION" address="74fc0" />
-  <table name="(P1400) FUEL TANK PRESSURE SOL. LOW" address="74f8b" />
-  <table name="(P1420) FUEL TANK PRESSURE SOL. HIGH INPUT" address="74f8c" />
-  <table name="(P1443) VENT CONTROL SOLENOID FUNCTION PROBLEM" address="74f91" />
-  <table name="(P1491) PCV (BLOWBY) FUNCTION PROBLEM" address="74fb3" />
-  <table name="(P1518) STARTER SWITCH LOW INPUT" address="74f75" />
-  <table name="(P1544) EGT TOO HIGH" address="74fc1" />
-  <table name="(P1560) BACK-UP VOLTAGE MALFUNCTION" address="74fb4" />
-  <table name="(P2004) TGV - INTAKE MANIFOLD RUNNER 1 STUCK OPEN" address="74fec" />
-  <table name="(P2005) TGV - INTAKE MANIFOLD RUNNER 2 STUCK OPEN" address="74fee" />
-  <table name="(P2006) TGV - INTAKE MANIFOLD RUNNER 1 STUCK CLOSED" address="74fed" />
-  <table name="(P2007) TGV - INTAKE MANIFOLD RUNNER 2 STUCK CLOSED" address="74fef" />
-  <table name="(P2008) TGV - INTAKE MANIFOLD RUNNER 1 CIRCUIT OPEN" address="74ffa" />
-  <table name="(P2009) TGV - INTAKE MANIFOLD RUNNER 1 CIRCUIT LOW" address="74ff8" />
-  <table name="(P2011) TGV - INTAKE MANIFOLD RUNNER 2 CIRCUIT OPEN" address="74ffb" />
-  <table name="(P2012) TGV - INTAKE MANIFOLD RUNNER 2 CIRCUIT LOW" address="74ff9" />
-  <table name="(P2016) TGV - INTAKE MANIFOLD RUNNER 1 POS. SENSOR LOW" address="74ff4" />
-  <table name="(P2017) TGV - INTAKE MANIFOLD RUNNER 1 POS. SENSOR HIGH" address="74ff5" />
-  <table name="(P2021) TGV - INTAKE MANIFOLD RUNNER 2 POS. SENSOR LOW" address="74ff6" />
-  <table name="(P2022) TGV - INTAKE MANIFOLD RUNNER 2 POS. SENSOR HIGH" address="74ff7" />
-  <table name="(P2088) OCV SOLENOID A1 CIRCUIT OPEN" address="74fe8" />
-  <table name="(P2089) OCV SOLENOID A1 CIRCUIT SHORT" address="74fe7" />
-  <table name="(P2092) OCV SOLENOID A2 CIRCUIT OPEN" address="74fe6" />
-  <table name="(P2093) OCV SOLENOID A2 CIRCUIT SHORT" address="74fe5" />
-  <table name="(P2096) POST CATALYST TOO LEAN B1" address="74fd1" />
-  <table name="(P2097) POST CATALYST TOO RICH B1" address="74fda" />
-  <table name="(P2101) THROTTLE ACTUATOR CIRCUIT RANGE/PERF" address="74fd0" />
-  <table name="(P2102) THROTTLE ACTUATOR CIRCUIT LOW" address="74fce" />
-  <table name="(P2103) THROTTLE ACTUATOR CIRCUIT HIGH" address="74fcf" />
-  <table name="(P2109) TPS A MINIMUM STOP PERF" address="74fca" />
-  <table name="(P2122) TPS D CIRCUIT LOW INPUT" address="74fd7" />
-  <table name="(P2123) TPS D CIRCUIT HIGH INPUT" address="74fd8" />
-  <table name="(P2127) TPS E CIRCUIT LOW INPUT" address="74fd5" />
-  <table name="(P2128) TPS E CIRCUIT HIGH INPUT" address="74fd6" />
-  <table name="(P2135) TPS A/B VOLTAGE" address="74fd9" />
-  <table name="(P2138) TPS D/E VOLTAGE" address="74fd4" />
-  <table name="(P2227) BARO. PRESSURE CIRCUIT RANGE/PERF" address="74ff0" />
-  <table name="(P2228) BARO. PRESSURE CIRCUIT LOW INPUT" address="74ff3" />
-  <table name="(P2229) BARO. PRESSURE CIRCUIT HIGH INPUT" address="74ff2" />
+	<romid>
+		<xmlid>A2WC521C</xmlid>
+		<internalidaddress>2000</internalidaddress>
+		<internalidstring>A2WC521C</internalidstring>
+		<ecuid>2F12505506</ecuid>
+		<make>Subaru</make>
+		<market>USDM</market>
+		<model>Legacy</model>
+		<submodel>GT</submodel>
+		<transmission>AT</transmission>
+		<year>05</year>
+		<flashmethod>sti05</flashmethod>
+		<memmodel>SH7058</memmodel>
+		<checksummodule>subarudbw</checksummodule>
+	</romid>
+
+	<include>32BITBASE</include>
+
+	<notes>2014/05/22 [Tactrix] Tactrix definition auto cleaned|merged w/ RomRaiderGitHubAlphaMay2014.
+</notes>
+
+
+	<table name="Target Boost A" address="c0fb4">
+		<table name="Throttle Plate Opening Angle" address="c0f64"/>
+		<table name="Engine Speed" address="c0f84"/>
+	</table>
+
+	<table name="Target Boost B" address="c10c4">
+		<table name="Throttle Plate Opening Angle" address="c1074"/>
+		<table name="Engine Speed" address="c1094"/>
+	</table>
+
+	<table name="Target Boost Compensation (ECT)" address="c0764">
+		<table name="Coolant Temperature" address="c05c4"/>
+	</table>
+
+	<table name="Target Boost Compensation (1st Gear)" address="c05c0">
+	</table>
+
+	<table name="Target Boost Compensation (1st Gear) Speed Disable" address="c05b8">
+	</table>
+
+	<table name="Target Boost Compensation (Atm. Pressure) Multiplier" address="c0864">
+		<table name="Engine Speed" address="c0854"/>
+	</table>
+
+	<table name="Target Boost Compensation (Atm. Pressure) Multiplier Offset" address="c0794">
+		<table name="Engine Speed" address="c0784"/>
+	</table>
+
+	<table name="Boost Limit (Fuel Cut)" address="c803c">
+		<table name="Atmospheric Pressure" address="c8024"/>
+	</table>
+
+	<table name="Boost Control Disable (IAM)" address="c0598">
+	</table>
+
+	<table name="Boost Control Disable (Fine Correction)" address="c0594">
+	</table>
+
+	<table name="Boost Control Disable Delay (Fine Correction)" address="c0535">
+	</table>
+
+	<table name="Initial Wastegate Duty A" address="c09c8">
+		<table name="Throttle Plate Opening Angle" address="c097c"/>
+		<table name="Engine Speed" address="c099c" elements="11"/>
+	</table>
+
+	<table name="Initial Wastegate Duty B" address="c0ac4">
+		<table name="Throttle Plate Opening Angle" address="c0a78"/>
+		<table name="Engine Speed" address="c0a98" elements="11"/>
+	</table>
+
+	<table name="Max Wastegate Duty" address="c0db8">
+		<table name="Throttle Plate Opening Angle" address="c0d6c"/>
+		<table name="Engine Speed" address="c0d8c" elements="11"/>
+	</table>
+
+	<table name="Max Wastegate Duty Alternate A (RPM)" address="c08c0">
+		<table name="Engine Speed" address="c08ac"/>
+	</table>
+
+	<table name="Max Wastegate Duty Alternate B (RPM)" address="c08e8">
+		<table name="Engine Speed" address="c08d4"/>
+	</table>
+
+	<table name="Wastegate Duty Ramping Fix_" address="c0588"/>
+
+	<table name="Max Wastegate Duty Alternate Fix" address="c0534"/>
+
+	<table name="Max Wastegate Duty Limit Post-Compensation" address="15618">
+	</table>
+
+	<table name="Initial/Max Wastegate Duty Compensation (IAT)" address="c0644">
+		<table name="Intake Temperature" address="c0604"/>
+	</table>
+
+	<table name="Initial/Max Wastegate Duty Alternate Compensation (IAT)" address="c06e4">
+		<table name="Intake Temperature" address="c06a4"/>
+	</table>
+
+	<table name="Initial/Max Wastegate Duty Compensation (ECT)" address="c0744">
+		<table name="Coolant Temperature" address="c05c4"/>
+	</table>
+
+	<table name="Initial/Max Wastegate Duty Compensation (Atm. Pressure)" address="c0924">
+		<table name="Atmospheric Pressure" address="c08fc"/>
+		<table name="Engine Speed" address="c0914"/>
+	</table>
+
+	<table name="Turbo Dynamics Proportional" address="c07d0">
+		<table name="Boost Error" address="c07ac"/>
+	</table>
+
+	<table name="Turbo Dynamics Integral Positive" address="c0840">
+		<table name="Boost Error" address="c081c"/>
+	</table>
+
+	<table name="Turbo Dynamics Integral Negative" address="c0808">
+		<table name="Boost Error" address="c07e4"/>
+	</table>
+
+	<table name="TD Activation Thresholds (RPM)" address="c056c">
+	</table>
+
+	<table name="TD Activation Thresholds (Target Boost)" address="c0540">
+	</table>
+
+	<table name="TD Integral Cumulative Range (WGDC Correction)" address="c057c">
+	</table>
+
+	<table name="TD Integral Negative Activation (Boost Error)" address="c0550">
+	</table>
+
+	<table name="TD Integral Positive Activation (Boost Error)" address="c0558">
+	</table>
+
+	<table name="TD Integral Positive Activation (Wastegate Duty)" address="c0560">
+	</table>
+
+	<table name="Manifold Pressure Sensor Scaling" address="c00c0">
+	</table>
+
+	<table name="Manifold Pressure Sensor Limits (CEL)" address="ccd9a">
+	</table>
+
+	<table name="Manifold Pressure Sensor CEL Delays" address="c310f">
+	</table>
+
+	<table name="Primary Open Loop Fueling" address="c87cc">
+		<table name="Engine Load" address="c8744" elements="16"/>
+		<table name="Engine Speed" address="c8784"/>
+	</table>
+
+	<table name="Primary Open Loop Fueling (Failsafe)" address="c8988">
+		<table name="Engine Load" address="c8900" elements="16"/>
+		<table name="Engine Speed" address="c8940"/>
+	</table>
+
+	<table name="Primary Open Loop Fuel Map Switch (IAM)" address="c7020">
+	</table>
+
+	<table name="Minimum Active Primary Open Loop Enrichment" address="c6f84">
+	</table>
+
+	<table name="Minimum Primary Open Loop Enrichment (Throttle)" address="c76bc">
+		<table name="Throttle Plate Opening Angle" address="c76a4"/>
+	</table>
+
+	<table name="Primary Open Loop Fueling Compensation (ECT)" address="c7e88">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Primary Open Loop Fueling Compensation (Timing Compensation)" address="c76dc">
+		<table name="'Timing Compensation (MRP)' + 'Timing Compensation (IAT)'" address="c76c4"/>
+	</table>
+
+	<table name="Front Oxygen Sensor Scaling" address="cd40c">
+		<table name="Front Oxygen Sensor" address="cd3d8"/>
+	</table>
+
+	<table name="Front Oxygen Sensor Rich Limit" address="22eb8">
+	</table>
+
+	<table name="Front Oxygen Sensor Compensation (Atm. Pressure)" address="c27f4">
+		<table name="Atmospheric Pressure" address="c27e4"/>
+	</table>
+
+	<table name="CL Fueling Target Compensation (Load)" address="c9208">
+		<table name="Engine Load" address="c91ac" elements="11"/>
+		<table name="Engine Speed" address="c91d8" elements="12"/>
+	</table>
+
+	<table name="CL Fueling Target Compensation A (ECT)" address="c9050">
+		<table name="Coolant Temperature" address="c7344"/>
+		<table name="Engine Load" address="c9044"/>
+	</table>
+
+	<table name="CL Fueling Target Compensation B (ECT)" address="c9104">
+		<table name="Coolant Temperature" address="c7344"/>
+		<table name="Engine Load" address="c90f8"/>
+	</table>
+
+	<table name="CL to OL Delay" address="c6bcc">
+	</table>
+
+	<table name="CL to OL Transition with Delay A (Throttle)" address="c75f4">
+		<table name="Engine Speed" address="c75b4"/>
+	</table>
+
+	<table name="CL to OL Transition with Delay B (Throttle)" address="c7644">
+		<table name="Engine Speed" address="c7604"/>
+	</table>
+
+	<table name="CL to OL Transition with Delay C (Throttle)" address="c7694">
+		<table name="Engine Speed" address="c7654"/>
+	</table>
+
+	<table name="CL to OL Transition with Delay Throttle Hysteresis" address="c6f88">
+	</table>
+
+	<table name="CL to OL Transition with Delay A (Base Pulse Width)" address="c7da8">
+		<table name="Engine Speed" address="c7d68"/>
+	</table>
+
+	<table name="CL to OL Transition with Delay B (Base Pulse Width)" address="c7e08">
+		<table name="Engine Speed" address="c7dc8"/>
+	</table>
+
+	<table name="CL to OL Transition with Delay C (Base Pulse Width)" address="c7e68">
+		<table name="Engine Speed" address="c7e28"/>
+	</table>
+
+	<table name="CL to OL Transition with Delay BPW Hysteresis" address="c6f8c">
+	</table>
+
+	<table name="CL Delay Maximum (EGT)" address="c7008">
+	</table>
+
+	<table name="CL Delay Maximum (Vehicle Speed)" address="c7000">
+	</table>
+
+	<table name="CL Delay Minimum (ECT)" address="c6f90">
+	</table>
+
+	<table name="CL Delay Maximum Engine Speed (Per Gear)" address="c6f94">
+	</table>
+
+	<table name="CL Delay Maximum Engine Speed (Neutral)" address="c6fe4">
+	</table>
+
+	<table name="CL Delay Throttle Atm. Pressure Thresholds" address="c7010">
+	</table>
+
+	<table name="CL Delay Maximum (Throttle) (Low Atm. Pressure)" address="c6ff4">
+	</table>
+
+	<table name="CL Delay Maximum (Throttle) (High Atm. Pressure)" address="c6fec">
+	</table>
+
+	<table name="Injector Latency" address="cce8c">
+		<table name="Battery Output" address="cce78"/>
+	</table>
+
+	<table name="Injector Flow Scaling" address="c6d1c">
+	</table>
+
+	<table name="Per Injector Primary Fuel Offset Compensation A" address="c8b00">
+		<table name="Last Calculated Base Pulse Width" address="c8aa8"/>
+		<table name="Engine Speed" address="c8ac8"/>
+	</table>
+
+	<table name="Per Injector Primary Fuel Offset Compensation B" address="c8bc8">
+		<table name="Last Calculated Base Pulse Width" address="c8b70"/>
+		<table name="Engine Speed" address="c8b90"/>
+	</table>
+
+	<table name="Per Injector Primary Fuel Offset Compensation C" address="c8c90">
+		<table name="Last Calculated Base Pulse Width" address="c8c38"/>
+		<table name="Engine Speed" address="c8c58"/>
+	</table>
+
+	<table name="Per Injector Primary Fuel Offset Compensation D" address="c8d58">
+		<table name="Last Calculated Base Pulse Width" address="c8d00"/>
+		<table name="Engine Speed" address="c8d20"/>
+	</table>
+
+	<table name="Cranking Fuel Injector Pulse Width A (ECT)" address="c78b2">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Cranking Fuel Injector Pulse Width B (ECT)" address="c78d2">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Cranking Fuel Injector Pulse Width C (ECT)" address="c78f2">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Cranking Fuel Injector Pulse Width D (ECT)" address="c7912">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Cranking Fuel IPW Compensation (RPM)" address="c85ec">
+		<table name="Engine Speed" address="c85bc"/>
+		<table name="Coolant Temperature" address="c85d0"/>
+	</table>
+
+	<table name="Cranking Fuel IPW Compensation (Accelerator)" address="c7440">
+		<table name="Accelerator Pedal Angle" address="c7428"/>
+	</table>
+
+	<table name="Throttle Tip-in Enrichment" address="c7f90">
+		<table name="Throttle Angle Change" address="c7f48"/>
+	</table>
+
+	<table name="Minimum Tip-in Enrichment Activation" address="c7110">
+	</table>
+
+	<table name="Minimum Tip-in Enrichment Activation (Throttle)" address="c710c">
+	</table>
+
+	<table name="Tip-in Enrichment Compensation (Boost Error)" address="c7750">
+		<table name="Boost Error" address="c772c"/>
+	</table>
+
+	<table name="Tip-in Enrichment Compensation (ECT)" address="c7fb4">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Tip-in Enrichment Disable Applied Counter Threshold" address="c6b95">
+	</table>
+
+	<table name="Tip-in Enrichment Applied Counter Reset" address="c6b96">
+	</table>
+
+	<table name="Tip-in Enrichment Disable Throttle Cumulative Threshold" address="c7114">
+	</table>
+
+	<table name="Tip-in Throttle Cumulative Reset" address="c6b97">
+	</table>
+
+	<table name="Min Primary Base Enrichment 1" address="c7496">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrichment 1 (Non-Primary OL)" address="c8718">
+		<table name="Coolant Temperature" address="c86ec" elements="8"/>
+		<table name="Engine Load" address="c870c"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 2 Initial Start 1A" address="c79b2">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 2 Initial Start 1B" address="c79f2">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 2 Initial Start 2A" address="c79d2">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 2 Initial Start 2B" address="c7a12">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 2 Decay Step 1" address="c7a32">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 2 Decay Step 2" address="c7a52">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 3 Initial Start 1A" address="c7932">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 3 Initial Start 1B" address="c7952">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 3 Initial Start 2A" address="c7972">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 3 Initial Start 2B" address="c7992">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 3 Decay Delay A" address="c7456">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 3 Decay Delay B" address="c7466">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Min Primary Base Enrich 3 Decay Multiplier" address="c6d20">
+	</table>
+
+	<table name="A/F Learning #1 Limits" address="c6f4c">
+	</table>
+
+	<table name="A/F Learning #1 Airflow Ranges" address="c6f58">
+	</table>
+
+	<table name="MAF Limit (Maximum)" address="c23a0">
+	</table>
+
+	<table name="MAF Sensor Scaling" address="cd210">
+		<table name="MAF sensor" address="cd138"/>
+	</table>
+
+	<table name="MAF Compensation (IAT)" address="c2bb8">
+		<table name="Intake Temperature" address="c2b84"/>
+		<table name="Mass Airflow" address="c2b98"/>
+	</table>
+
+	<table name="Engine Load Limit (Maximum)" address="20f90">
+	</table>
+
+	<table name="Engine Load Compensation (MP)" address="c2b2c">
+		<table name="Manifold Pressure" address="c2ae0"/>
+		<table name="Engine Speed" address="c2b0c" elements="8"/>
+	</table>
+
+	<table name="Base Timing" address="ca018">
+		<table name="Engine Load" address="c9f90" elements="16"/>
+		<table name="Engine Speed" address="c9fd0"/>
+	</table>
+
+	<table name="Base Timing Idle" address="c9871">
+		<table name="Coolant Temperature" address="c9714"/>
+	</table>
+
+	<table name="Base Timing Idle Minimum" address="c9868">
+		<table name="Engine Speed" address="c9844"/>
+	</table>
+
+	<table name="Base Timing Idle Minimum Vehicle Speed Enable" address="c945c">
+	</table>
+
+	<table name="Knock Correction Advance Max" address="ca57c">
+		<table name="Engine Load" address="ca4f4"/>
+		<table name="Engine Speed" address="ca534"/>
+	</table>
+
+	<table name="Timing Compensation A (IAT)" address="c98e4">
+		<table name="Intake Temperature" address="c98a4"/>
+	</table>
+
+	<table name="Timing Compensation A (IAT) Activation" address="ca178">
+		<table name="Engine Speed" address="ca138"/>
+		<table name="Engine Load" address="ca158"/>
+	</table>
+
+	<table name="Timing Compensation B (IAT)" address="c9c5c">
+		<table name="Intake Temperature" address="c9c1c"/>
+	</table>
+
+	<table name="Timing Compensation B (IAT) IAM Activation" address="c9710">
+	</table>
+
+	<table name="Timing Compensation B (IAT) Max Additive" address="c96f4">
+	</table>
+
+	<table name="Timing Compensation (ECT)" address="c9891">
+		<table name="Coolant Temperature" address="c9714"/>
+	</table>
+
+	<table name="Timing Compensation (MRP)" address="ca6d0">
+		<table name="Atmospheric Pressure" address="ca6b0"/>
+		<table name="Manifold Relative Pressure" address="ca6c4"/>
+	</table>
+
+	<table name="Timing Compensation Per Cylinder A" address="ca308">
+		<table name="Engine Speed" address="ca2c0"/>
+		<table name="Engine Load" address="ca2f8"/>
+	</table>
+
+	<table name="Timing Compensation Per Cylinder B" address="ca388">
+		<table name="Engine Speed" address="ca340"/>
+		<table name="Engine Load" address="ca378"/>
+	</table>
+
+	<table name="Timing Compensation Per Cylinder C" address="ca408">
+		<table name="Engine Speed" address="ca3c0"/>
+		<table name="Engine Load" address="ca3f8"/>
+	</table>
+
+	<table name="Timing Compensation Per Cylinder D" address="ca488">
+		<table name="Engine Speed" address="ca440"/>
+		<table name="Engine Load" address="ca478"/>
+	</table>
+
+	<table name="Timing Comp Minimum Load (Per Cylinder)" address="c9570">
+	</table>
+
+	<table name="Timing Comp Maximum RPM (Per Cylinder)" address="c956c">
+	</table>
+
+	<table name="Timing Comp Minimum Coolant Temp (Per Cylinder)" address="c9574">
+	</table>
+
+	<table name="Feedback Correction Range (RPM)" address="c95a8">
+	</table>
+
+	<table name="Feedback Correction Minimum Load" address="c95b8">
+	</table>
+
+	<table name="Feedback Correction Retard Value" address="c9588">
+	</table>
+
+	<table name="Feedback Correction Retard Limit" address="c9584">
+	</table>
+
+	<table name="Feedback Correction Negative Advance Value" address="c9590">
+	</table>
+
+	<table name="Feedback Correction Negative Advance Delay" address="c9388">
+	</table>
+
+	<table name="Extended Feedback Correction High RPM Compensation" address="c95c0">
+	</table>
+
+	<table name="Fine Correction Range (RPM)" address="c96a0">
+	</table>
+
+	<table name="Fine Correction Range (Load)" address="c96b0">
+	</table>
+
+	<table name="Fine Correction Rows (RPM)" address="c96d0">
+	</table>
+
+	<table name="Fine Correction Columns (Load)" address="c96c0">
+	</table>
+
+	<table name="Fine Correction Retard Value" address="c96e8">
+	</table>
+
+	<table name="Fine Correction Retard Limit" address="c9698">
+	</table>
+
+	<table name="Fine Correction Advance Value" address="c969c">
+	</table>
+
+	<table name="Fine Correction Advance Limit" address="c9694">
+	</table>
+
+	<table name="Fine Correction Advance Delay" address="c9396">
+	</table>
+
+	<table name="Rough Correction Range (RPM)" address="c9638">
+	</table>
+
+	<table name="Rough Correction Range (Load)" address="c9648">
+	</table>
+
+	<table name="Rough Correction Minimum KC Advance Map Value" address="c9658">
+	</table>
+
+	<table name="Rough Correction Learning Delay (Increasing)" address="c9c10">
+		<table name="Engine Speed" address="c9be8"/>
+	</table>
+
+	<table name="Advance Multiplier (Initial)" address="c9634">
+	</table>
+
+	<table name="Advance Multiplier Step Value" address="c965c">
+	</table>
+
+	<table name="Intake Cam Advance Angle (AVCS)" address="ce74c">
+		<table name="Engine Load" address="ce6fc" elements="10"/>
+		<table name="Engine Speed" address="ce724" elements="10"/>
+	</table>
+
+	<table name="Requested Torque (Accelerator Pedal)" address="cc014">
+		<table name="Accelerator Pedal Angle" address="cbf9c"/>
+		<table name="Engine Speed" address="cbfd8" elements="15"/>
+	</table>
+
+	<table name="Target Throttle Plate Position (Requested Torque)" address="cbd7c">
+		<table name="Requested Torque" address="cbcf8"/>
+		<table name="Engine Speed" address="cbd3c"/>
+	</table>
+
+	<table name="Rev Limit (Fuel Cut)" address="c7164">
+	</table>
+
+	<table name="Rev Limit Fuel Resume (Boost)" address="c716c">
+	</table>
+
+	<table name="Speed Limiting Enable (Fuel Cut)" address="c71b0">
+	</table>
+
+	<table name="Speed Limiting Disable (Fuel Cut)" address="c71b8">
+	</table>
+
+	<table name="Speed Limiting (Throttle)" address="c2658">
+	</table>
+
+	<table name="EGT Sensor Scaling" address="cd360">
+		<table name="Exhaust Gas Temperature Sensor" address="cd2e8"/>
+	</table>
+
+	<table name="Fuel Temp Sensor Scaling" address="cd0c0">
+		<table name="Fuel Temp Sensor" address="cd048"/>
+	</table>
+
+	<table name="Intake Temp Sensor Scaling" address="85964">
+		<table name="Intake Temp Sensor" address="858ec"/>
+	</table>
+
+	<table name="Coolant Temp Sensor Scaling" address="8587c">
+		<table name="Coolant Temp Sensor" address="8580c"/>
+	</table>
+
+	<table name="Atmospheric Pressure Sensor Scaling" address="c0070">
+	</table>
+
+	<table name="Radiator Fan Modes (ECT)" address="cdb68">
+	</table>
+
+	<table name="Radiator Fan Modes (Veh. Speed)" address="cdb78">
+	</table>
+
+	<table name="Idle Speed Target A" address="cb2dc">
+		<table name="Coolant Temperature" address="cac94"/>
+	</table>
+
+	<table name="Idle Speed Target B" address="cb31c">
+		<table name="Coolant Temperature" address="cac94"/>
+	</table>
+
+	<table name="Idle Speed Target C" address="cb35c">
+		<table name="Coolant Temperature" address="cac94"/>
+	</table>
+
+	<table name="Force Pass Readiness Monitors" address="78252"/>
+
+	<table name="(P0000) PASS CODE (NO DTC DETECTED)" address="74fa3"/>
+
+	<table name="(P0000) PASS CODE (NO DTC DETECTED)_" address="74fa4"/>
+
+	<table name="(P0011) CAMSHAFT POS. - TIMING OVER-ADVANCED 1" address="74f89"/>
+
+	<table name="(P0021) CAMSHAFT POS. - TIMING OVER-ADVANCED 2" address="74f8a"/>
+
+	<table name="(P0030) FRONT O2 SENSOR RANGE/PERF" address="74fc8"/>
+
+	<table name="(P0031) FRONT O2 SENSOR LOW INPUT" address="74faf"/>
+
+	<table name="(P0032) FRONT O2 SENSOR HIGH INPUT" address="74fad"/>
+
+	<table name="(P0037) REAR O2 SENSOR LOW INPUT" address="74fae"/>
+
+	<table name="(P0038) REAR O2 SENSOR HIGH INPUT" address="74fac"/>
+
+	<table name="(P0068) MAP SENSOR RANGE/PERF" address="74fc4"/>
+
+	<table name="(P0101) MAF SENSOR RANGE/PERF" address="74fc6"/>
+
+	<table name="(P0102) MAF SENSOR LOW INPUT" address="74f65"/>
+
+	<table name="(P0103) MAF SENSOR HIGH INPUT" address="74f66"/>
+
+	<table name="(P0107) MAP SENSOR LOW INPUT" address="74fb0"/>
+
+	<table name="(P0108) MAP SENSOR HIGH INPUT" address="74fb1"/>
+
+	<table name="(P0111) IAT SENSOR RANGE/PERF" address="74fab"/>
+
+	<table name="(P0112) IAT SENSOR LOW INPUT" address="74fa9"/>
+
+	<table name="(P0113) IAT SENSOR HIGH INPUT" address="74faa"/>
+
+	<table name="(P0117) COOLANT TEMP SENSOR LOW INPUT" address="74f6d"/>
+
+	<table name="(P0118) COOLANT TEMP SENSOR HIGH INPUT" address="74f6e"/>
+
+	<table name="(P0122) TPS A LOW INPUT" address="74f6a"/>
+
+	<table name="(P0123) TPS A HIGH INPUT" address="74f6b"/>
+
+	<table name="(P0125) INSUFFICIENT COOLANT TEMP (FUELING)" address="74f70"/>
+
+	<table name="(P0126) INSUFFICIENT COOLANT TEMP (OPERATION)" address="74ff1"/>
+
+	<table name="(P0128) THERMOSTAT MALFUNCTION" address="74fb2"/>
+
+	<table name="(P0131) FRONT O2 SENSOR LOW INPUT" address="74fa6"/>
+
+	<table name="(P0132) FRONT O2 SENSOR HIGH INPUT" address="74fa7"/>
+
+	<table name="(P0133) FRONT O2 SENSOR SLOW RESPONSE" address="74f94"/>
+
+	<table name="(P0134) FRONT O2 SENSOR NO ACTIVITY" address="74fc7"/>
+
+	<table name="(P0137) REAR O2 SENSOR LOW VOLTAGE" address="74fa5"/>
+
+	<table name="(P0138) REAR O2 SENSOR HIGH VOLTAGE" address="74fa8"/>
+
+	<table name="(P0139) REAR O2 SENSOR SLOW RESPONSE" address="74f95"/>
+
+	<table name="(P0171) SYSTEM TOO LEAN" address="74f9b"/>
+
+	<table name="(P0172) SYSTEM TOO RICH" address="74f9c"/>
+
+	<table name="(P0181) FUEL TEMP SENSOR A RANGE/PERF" address="74f7d"/>
+
+	<table name="(P0182) FUEL TEMP SENSOR A LOW INPUT" address="74f7b"/>
+
+	<table name="(P0183) FUEL TEMP SENSOR A HIGH INPUT" address="74f7c"/>
+
+	<table name="(P0222) TPS B LOW INPUT" address="74fcb"/>
+
+	<table name="(P0223) TPS B HIGH INPUT" address="74fcc"/>
+
+	<table name="(P0230) FUEL PUMP PRIMARY CIRCUIT" address="74fc3"/>
+
+	<table name="(P0244) WASTEGATE SOLENOID A RANGE/PERF" address="74fb9"/>
+
+	<table name="(P0245) WASTEGATE SOLENOID A LOW" address="74fb7"/>
+
+	<table name="(P0246) WASTEGATE SOLENOID A HIGH" address="74fb8"/>
+
+	<table name="(P0301) MISFIRE CYLINDER 1" address="74f9d"/>
+
+	<table name="(P0302) MISFIRE CYLINDER 2" address="74f9e"/>
+
+	<table name="(P0303) MISFIRE CYLINDER 3" address="74f9f"/>
+
+	<table name="(P0304) MISFIRE CYLINDER 4" address="74fa0"/>
+
+	<table name="(P0327) KNOCK SENSOR 1 LOW INPUT" address="74f68"/>
+
+	<table name="(P0328) KNOCK SENSOR 1 HIGH INPUT" address="74f69"/>
+
+	<table name="(P0335) CRANKSHAFT POS. SENSOR A MALFUNCTION" address="74f60"/>
+
+	<table name="(P0336) CRANKSHAFT POS. SENSOR A RANGE/PERF" address="74f61"/>
+
+	<table name="(P0340) CAMSHAFT POS. SENSOR A MALFUNCTION_" address="74fdf"/>
+
+	<table name="(P0345) CAMSHAFT POS. SENSOR A BANK 2" address="74fde"/>
+
+	<table name="(P0420) CAT EFFICIENCY BELOW THRESHOLD" address="74f98"/>
+
+	<table name="(P0442) EVAP LEAK DETECTED (SMALL)" address="74f99"/>
+
+	<table name="(P0447) EVAP VENT CONTROL CIRCUIT OPEN" address="74f92"/>
+
+	<table name="(P0448) EVAP VENT CONTROL CIRCUIT SHORTED" address="74f93"/>
+
+	<table name="(P0451) EVAP PRESSURE SENSOR RANGE/PERF" address="74f79"/>
+
+	<table name="(P0452) EVAP PRESSURE SENSOR LOW INPUT" address="74f77"/>
+
+	<table name="(P0453) EVAP PRESSURE SENSOR HIGH INPUT" address="74f78"/>
+
+	<table name="(P0456) EVAP LEAK DETECTED (VERY SMALL)" address="74f9a"/>
+
+	<table name="(P0457) EVAP LEAK DETECTED (FUEL CAP)" address="74fa2"/>
+
+	<table name="(P0458) EVAP PURGE VALVE CIRCUIT LOW" address="74f8d"/>
+
+	<table name="(P0459) EVAP PURGE VALVE CIRCUIT HIGH" address="74f8e"/>
+
+	<table name="(P0461) FUEL LEVEL SENSOR RANGE/PERF" address="74f73"/>
+
+	<table name="(P0462) FUEL LEVEL SENSOR LOW INPUT" address="74f71"/>
+
+	<table name="(P0463) FUEL LEVEL SENSOR HIGH INPUT" address="74f72"/>
+
+	<table name="(P0464) FUEL LEVEL SENSOR INTERMITTENT" address="74f6f"/>
+
+	<table name="(P0483) RADIATOR FAN RATIONALITY CHECK" address="74f85"/>
+
+	<table name="(P0500) VEHICLE SPEED SENSOR A" address="74f67"/>
+
+	<table name="(P0506) IDLE CONTROL RPM LOWER THAN EXPECTED" address="74f81"/>
+
+	<table name="(P0507) IDLE CONTROL RPM HIGH THAN EXPECTED" address="74f82"/>
+
+	<table name="(P0512) STARTER REQUEST CIRCUIT" address="74f76"/>
+
+	<table name="(P0519) IDLE CONTROL MALFUNCTION (FAIL-SAFE)" address="74fc5"/>
+
+	<table name="(P0545) EGT SENSOR CIRCUIT LOW" address="74fbe"/>
+
+	<table name="(P0546) EGT SENSOR CIRCUIT HIGH" address="74fbf"/>
+
+	<table name="(P0600) SERIAL COMMUNICATION LINK" address="74fdb"/>
+
+	<table name="(P0604) CONTROL MODULE RAM ERROR" address="74f64"/>
+
+	<table name="(P0605) CONTROL MODULE ROM ERROR" address="74fe0"/>
+
+	<table name="(P0607) CONTROL MODULE PERFORMANCE" address="74fd3"/>
+
+	<table name="(P0638) THROTTLE ACTUATOR RANGE/PERF" address="74fd2"/>
+
+	<table name="(P0691) RADIATOR FAN CIRCUIT LOW" address="74f83"/>
+
+	<table name="(P0692) RADIATOR FAN CIRCUIT HIGH" address="74f84"/>
+
+	<table name="(P0700) TRANSMISSION CONTROL SYSTEM" address="74fe9"/>
+
+	<table name="(P0851) NEUTRAL SWITCH INPUT LOW" address="74f7a"/>
+
+	<table name="(P0852) NEUTRAL SWITCH INPUT HIGH" address="74f7e"/>
+
+	<table name="(P1152) FRONT O2 SENSOR RANGE/PERF LOW B1 S1" address="74f96"/>
+
+	<table name="(P1153) FRONT O2 SENSOR RANGE/PERF HIGH B1 S1" address="74f97"/>
+
+	<table name="(P1160) ABNORMAL RETURN SPRING" address="74fcd"/>
+
+	<table name="(P1301) MISFIRE (HIGH TEMP EXHAUST GAS)" address="74fa1"/>
+
+	<table name="(P1312) EGT SENSOR MALFUNCTION" address="74fc0"/>
+
+	<table name="(P1400) FUEL TANK PRESSURE SOL. LOW" address="74f8b"/>
+
+	<table name="(P1420) FUEL TANK PRESSURE SOL. HIGH INPUT" address="74f8c"/>
+
+	<table name="(P1443) VENT CONTROL SOLENOID FUNCTION PROBLEM" address="74f91"/>
+
+	<table name="(P1491) PCV (BLOWBY) FUNCTION PROBLEM" address="74fb3"/>
+
+	<table name="(P1518) STARTER SWITCH LOW INPUT" address="74f75"/>
+
+	<table name="(P1544) EGT TOO HIGH" address="74fc1"/>
+
+	<table name="(P1560) BACK-UP VOLTAGE MALFUNCTION" address="74fb4"/>
+
+	<table name="(P2004) TGV - INTAKE MANIFOLD RUNNER 1 STUCK OPEN" address="74fec"/>
+
+	<table name="(P2005) TGV - INTAKE MANIFOLD RUNNER 2 STUCK OPEN" address="74fee"/>
+
+	<table name="(P2006) TGV - INTAKE MANIFOLD RUNNER 1 STUCK CLOSED" address="74fed"/>
+
+	<table name="(P2007) TGV - INTAKE MANIFOLD RUNNER 2 STUCK CLOSED" address="74fef"/>
+
+	<table name="(P2008) TGV - INTAKE MANIFOLD RUNNER 1 CIRCUIT OPEN" address="74ffa"/>
+
+	<table name="(P2009) TGV - INTAKE MANIFOLD RUNNER 1 CIRCUIT LOW" address="74ff8"/>
+
+	<table name="(P2011) TGV - INTAKE MANIFOLD RUNNER 2 CIRCUIT OPEN" address="74ffb"/>
+
+	<table name="(P2012) TGV - INTAKE MANIFOLD RUNNER 2 CIRCUIT LOW" address="74ff9"/>
+
+	<table name="(P2016) TGV - INTAKE MANIFOLD RUNNER 1 POS. SENSOR LOW" address="74ff4"/>
+
+	<table name="(P2017) TGV - INTAKE MANIFOLD RUNNER 1 POS. SENSOR HIGH" address="74ff5"/>
+
+	<table name="(P2021) TGV - INTAKE MANIFOLD RUNNER 2 POS. SENSOR LOW" address="74ff6"/>
+
+	<table name="(P2022) TGV - INTAKE MANIFOLD RUNNER 2 POS. SENSOR HIGH" address="74ff7"/>
+
+	<table name="(P2088) OCV SOLENOID A1 CIRCUIT OPEN" address="74fe8"/>
+
+	<table name="(P2089) OCV SOLENOID A1 CIRCUIT SHORT" address="74fe7"/>
+
+	<table name="(P2092) OCV SOLENOID A2 CIRCUIT OPEN" address="74fe6"/>
+
+	<table name="(P2093) OCV SOLENOID A2 CIRCUIT SHORT" address="74fe5"/>
+
+	<table name="(P2096) POST CATALYST TOO LEAN B1" address="74fd1"/>
+
+	<table name="(P2097) POST CATALYST TOO RICH B1" address="74fda"/>
+
+	<table name="(P2101) THROTTLE ACTUATOR CIRCUIT RANGE/PERF" address="74fd0"/>
+
+	<table name="(P2102) THROTTLE ACTUATOR CIRCUIT LOW" address="74fce"/>
+
+	<table name="(P2103) THROTTLE ACTUATOR CIRCUIT HIGH" address="74fcf"/>
+
+	<table name="(P2109) TPS A MINIMUM STOP PERF" address="74fca"/>
+
+	<table name="(P2122) TPS D CIRCUIT LOW INPUT" address="74fd7"/>
+
+	<table name="(P2123) TPS D CIRCUIT HIGH INPUT" address="74fd8"/>
+
+	<table name="(P2127) TPS E CIRCUIT LOW INPUT" address="74fd5"/>
+
+	<table name="(P2128) TPS E CIRCUIT HIGH INPUT" address="74fd6"/>
+
+	<table name="(P2135) TPS A/B VOLTAGE" address="74fd9"/>
+
+	<table name="(P2138) TPS D/E VOLTAGE" address="74fd4"/>
+
+	<table name="(P2227) BARO. PRESSURE CIRCUIT RANGE/PERF" address="74ff0"/>
+
+	<table name="(P2228) BARO. PRESSURE CIRCUIT LOW INPUT" address="74ff3"/>
+
+	<table name="(P2229) BARO. PRESSURE CIRCUIT HIGH INPUT" address="74ff2"/>
+
+	<table name="AF 3 Correction Limits" address="2df2c"/>
+
+	<table name="Cluster Display Fuel Consumption Correction" address="c1428"/>
+
+	<table name="Low Pulse Width Fuel Injector Compensation" address="c7724">
+		<table name="Injector Pulse Width" address="c7704"/>
+	</table>
+
+	<table name="Low pulse width fuel injector compensation maximum RPM" address="c70fc"/>
+
+	<table name="Low pulse width fuel injector compensation maximum IPW" address="c7100"/>
+
+	<table name="Fuel Pump Duty" address="3ad04"/>
+
+	<table name="A/F #1 Learning Max Threshold" address="c6f64"/>
+
+	<table name="A/F #1 Learning Min Threshold" address="c6f54"/>
+
+	<table name="AF 3 CL Target Compensation Limits" address="2c91c">
+		<table name="X">
+			<data>Low</data>
+			<data>High</data>
+		</table>
+	</table>
+
+	<table name="Tau Input A Falling Load Activation" address="c7ab2">
+		<table name="Coolant Temperature" address="c7344"/>
+	</table>
+
+	<table name="Tau Input B Activation (Engine Load)" address="c7b94">
+		<table name="Engine Load" address="c7b68"/>
+	</table>
+
+	<table name="Tau Input A Rising Load Activation" address="c8fe4">
+		<table name="Coolant Temperature" address="c7344"/>
+		<table name="Engine Load" address="c8fd8"/>
+	</table>
 </rom>


### PR DESCRIPTION
The manual rom (521N) for the 05 Legacy GT has always had the alpha definitions for tau tables, instrument panel fuel correction, LPW injector compensations, fuel pump duty, etc while the automatic rom (521C) did not. A few of these just needed the exact same addresses input to the table definitions however for most I compared the two roms in a hex editor and found the new table locations for the automatic rom. There are reasons to use the automatic rom vs the manual even though they produce similar results - for example the neutral safety switch setup is different on a manual vs automatic so switching to another version disables cruise control while in drive but enables while in neutral.